### PR TITLE
Porting del servizio di spedizione delle notifiche delle ricevute di …

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2026-06-09  Giuliano Pintori <pintori@link.it>
 
+	* [Feature]
+	Porting del servizio di spedizione delle notifiche delle ricevute di pagamento (RT) all'API di integrazione dell'Ente, allineato al monolite GovPay (NotificheBD + InviaNotificaThread + RicevuteConverter).
+	Nuovo job batch indipendente rtSendJob, separato da rtNotifyJob: reader paginato sulla tabella notifiche (tipo_esito=RICEVUTA, stato=DA_SPEDIRE, data_prossima_spedizione<now), processor che spedisce via govpay-ec-client 2.0.0-SNAPSHOT (NotificaRicevuteApi, v2 EC API: PUT /ricevute/{idDominio}/{iuv}/{idRicevuta}), writer in transazione per item con tre transizioni di stato: SUCCESS->updateSpedito, ERROR->updateDaSpedire con backoff quadratico (tentativi^2*60s capped a 24h), ABORT->updateAnnullata con sentinel "mai" (9999-02-01).
+	Nuovo runner @Scheduled (@Profile("default"), feature flag govpay.batch.rt-send.enabled=false di default).
+	Entity locali Notifica, Rpt + enum StatoSpedizione/TipoNotifica.
+	RicevutaV2Mapper popola il payload Ricevuta v2 con i campi disponibili in DB: dominio, iuv, idRicevuta, importo, esito, data/dataPagamento, istitutoAttestante, rt (xml grezzo + tipo CT_RICEVUTA_TELEMATICA/CT_RECEIPT in base alla colonna versione della RPT).
+	Solo la v2 dell'EC API e' supportata: connettori configurati su versioni diverse vengono trattati come ABORT (notifica annullata). Issue separata predisposta per esporre la versione del connettore su govpay-common in modo strong-typed (docs/issues/govpay-common-versione-connettore.md); workaround temporaneo: lettura via ConnettoreService.getConnettoreAsMap.
+	Timeout HTTP del client EC letti da properties (govpay.batch.rt-send.http.connect-timeout-ms / read-timeout-ms).
+	Schedulazione tramite cron Spring (default scheduler.rtSendJob.cron=0 * * * * *, ogni minuto al secondo 0) in linea col monolite GovPay (le notifiche venivano inserite nella coda alla ricezione della RT e spedite entro un minuto).
+
 	* [Pipeline]
 	Allineata la gestione della cache OWASP/NVD a quella di govpay-common.
 	La chiave di cache include ora anche la versione del plugin OWASP (letta da pom.xml tramite mvn help:evaluate -Dexpression=owasp.plugin.version, definita nel govpay-bom): runner.os-owasp-v{version}-{date}, con restore-key runner.os-owasp-v{version}-. Un bump del plugin invalida quindi automaticamente la cache (lo schema del DB NVD cambia tra release). Aggiornati sia maven.yml sia refresh-owasp-db.yml.

--- a/docs/issues/govpay-common-versione-connettore.md
+++ b/docs/issues/govpay-common-versione-connettore.md
@@ -1,0 +1,97 @@
+# Esporre la versione dell'API EC sul modello `Connettore`
+
+## Contesto
+
+In `govpay-notify-batch` stiamo aggiungendo un nuovo job batch per la
+spedizione delle notifiche delle **ricevute di pagamento** (RT) verso le API
+di integrazione dell'Ente Creditore. L'API EC esiste in due versioni
+(`REST_1` -> `POST /pagamenti/{codDominio}/{iuv}` e
+`REST_2` -> `PUT /ricevute/{idDominio}/{iuv}/{idRicevuta}`) e il client da
+usare va scelto a runtime in funzione della versione configurata sul
+connettore di integrazione dell'applicazione.
+
+Nel monolite GovPay la dispatch e' centralizzata in
+`it.govpay.core.utils.client.NotificaClient#invoke()` e si basa su
+`applicazione.getConnettoreIntegrazione().getVersione()`, dove
+`Connettore extends Versionabile` e quindi espone direttamente l'enum
+`Versione` (`GP_REST_01`, `GP_REST_02`, ...).
+
+## Problema
+
+In `govpay-common` 2.0.0-SNAPSHOT il modello runtime
+`it.govpay.common.client.model.Connettore` **non** espone la versione
+dell'API: la proprieta' esiste solo come riga key/value nella tabella
+`connettori` (`cod_proprieta = 'VERSIONE'`, `valore = 'REST_1' | 'REST_2'`,
+costante `Connettore.P_VERSIONE` nel monolite). I consumer
+(`govpay-notify-batch`, gli altri batch satellite) devono quindi:
+
+1. chiamare `ConnettoreService.getConnettoreAsMap(codConnettore)`,
+2. estrarre la stringa `"VERSIONE"`,
+3. fare il parse a mano in un enum locale.
+
+Questo:
+
+- duplica logica di parsing in ogni consumer,
+- non e' coerente con il monolite (che e' la fonte autorevole dello schema),
+- rende fragile l'evoluzione (se domani la stringa cambia da `REST_2` a `REST_3`,
+  vanno aggiornati tutti i consumer).
+
+## Proposta
+
+Allineare il modello `Connettore` di `govpay-common` al pattern del monolite
+esponendo la versione come campo tipizzato del model runtime.
+
+### Modifiche richieste
+
+1. **Aggiungere un enum** `it.govpay.common.entity.VersioneApi` (oppure
+   riusare un enum gia' presente in govpay-common, se esiste un equivalente).
+   Valori minimi: `REST_1`, `REST_2`. Suggerito `fromValue(String)` /
+   `getValue()` per la conversione dalla rappresentazione DB.
+
+2. **Aggiungere il campo `versione`** al model
+   `it.govpay.common.client.model.Connettore`:
+
+   ```java
+   private VersioneApi versione;
+   public VersioneApi getVersione() { return this.versione; }
+   public void setVersione(VersioneApi versione) { this.versione = versione; }
+   ```
+
+3. **Popolare il campo** durante la conversione da entity a model nel
+   service / factory che oggi compone `Connettore` dalla mappa di proprieta'
+   (`ConnettoreService` / `RestTemplateFactory`): quando si incontra la
+   proprieta' `VERSIONE`, valorizzare il campo strong-typed.
+
+4. **Default e tolleranza al null**: se la proprieta' non e' configurata sul
+   connettore, lasciare `versione = null`. La scelta del default applicativo
+   resta in capo al consumer (es. `govpay-notify-batch` puo' decidere di
+   trattare `null` come `REST_2`).
+
+5. **Backwards compatibility**: la mappa restituita da
+   `ConnettoreService.getConnettoreAsMap(codConnettore)` deve continuare a
+   contenere anche la chiave `VERSIONE` come oggi, per non rompere i consumer
+   che la leggono in quel modo.
+
+### Test
+
+- Unit test sul service/factory che compone `Connettore`: dato un set di
+  righe key/value che include `VERSIONE=REST_2`, verificare che
+  `getVersione() == VersioneApi.REST_2`.
+- Caso `VERSIONE` assente -> `getVersione() == null`.
+- Caso `VERSIONE` con valore non riconosciuto -> definire policy (eccezione
+  in fase di load, oppure `null` + warning log). Suggerito: eccezione, per
+  evitare invii silenziosi sulla versione "sbagliata".
+
+## Versione target
+
+`govpay-common` 2.0.1-SNAPSHOT (o piu' in generale: prima della release
+stabile 2.0.0, se ancora aperta).
+
+## Riferimenti
+
+- `it.govpay.model.Versionabile` (monolite GovPay): definizione enum
+  `Versione`, parent di `Connettore`.
+- `it.govpay.bd.model.converter.ConnettoreConverter` (monolite GovPay):
+  read/write della proprieta' `Connettore.P_VERSIONE` su tabella `connettori`.
+- `it.govpay.core.utils.client.NotificaClient#invoke()`: dispatch v1/v2
+  basato su `connettoreIntegrazione.getVersione()`.

--- a/src/main/java/it/govpay/notify/batch/Costanti.java
+++ b/src/main/java/it/govpay/notify/batch/Costanti.java
@@ -17,8 +17,21 @@ public class Costanti {
     // Nome job RT notify
     public static final String RT_NOTIFY_JOB_NAME = "rtNotifyJob";
 
+    // Nome job di spedizione delle notifiche delle ricevute di pagamento (RT) all'Ente
+    public static final String RT_SEND_JOB_NAME = "rtSendJob";
+
+    // Versione API EC supportata oggi dal client generato (vedi NotificaRicevuteApi)
+    public static final String VERSIONE_API_EC_SUPPORTATA = "REST_2";
+
+    // Chiave della proprieta' "VERSIONE" nella tabella connettori (cfr. it.govpay.model.Connettore.P_VERSIONE del monolite)
+    public static final String CONNETTORE_PROPRIETA_VERSIONE = "VERSIONE";
+
+    // Lunghezza massima della colonna descrizione_stato della tabella notifiche (cfr. govpay master)
+    public static final int NOTIFICHE_DESCRIZIONE_STATO_MAX_LEN = 255;
+
     // Non sono URI completi (mancano protocollo e host) con il baseUrl configurabile tramite il Connettore nel DB.
     public static final String PATH_NOTIFY_RND = "/rendicontazioni";
+    public static final String PATH_NOTIFY_RT = "/ricevute";
 
     private Costanti() {
         // Costruttore privato per evitare istanziazione

--- a/src/main/java/it/govpay/notify/batch/controller/BatchController.java
+++ b/src/main/java/it/govpay/notify/batch/controller/BatchController.java
@@ -1,6 +1,7 @@
 package it.govpay.notify.batch.controller;
 
 import java.time.ZoneId;
+import java.util.concurrent.CompletableFuture;
 
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.repository.JobRepository;
@@ -31,18 +32,21 @@ import lombok.extern.slf4j.Slf4j;
 public class BatchController extends AbstractBatchController {
 
     private final Job rtNotifyJob;
+    private final Job rtSendJob;
     private final EnteApiService enteApiService;
 
     public BatchController(
             JobExecutionHelper jobExecutionHelper,
             JobRepository jobRepository,
             @Qualifier("rtNotifyJob") Job rtNotifyJob,
+            @Qualifier("rtSendJob") Job rtSendJob,
             EnteApiService enteApiService,
             Environment environment,
             ZoneId applicationZoneId,
             @Value("${scheduler.rtNotifyJob.fixedDelayString:7200000}") long schedulerIntervalMillis) {
         super(jobExecutionHelper, jobRepository, environment, applicationZoneId, schedulerIntervalMillis);
         this.rtNotifyJob = rtNotifyJob;
+        this.rtSendJob = rtSendJob;
         this.enteApiService = enteApiService;
     }
 
@@ -62,10 +66,43 @@ public class BatchController extends AbstractBatchController {
         return ResponseEntity.ok("Cache connettori svuotata");
     }
 
+    /**
+     * Esegue manualmente i job batch del progetto.
+     * <p>
+     * Primo job: {@code rtNotifyJob} (notifica delle rendicontazioni), gestito dalla
+     * superclasse — risponde con {@code 202 Accepted} se libero, {@code 409 Conflict}
+     * se gia' in esecuzione (vedi {@link AbstractBatchController#eseguiJob}).
+     * <p>
+     * Secondo job: {@code rtSendJob} (spedizione delle ricevute di pagamento), lanciato
+     * "best effort" in modo asincrono dopo il primo: il pre-check di concorrenza e' fatto
+     * da {@link JobExecutionHelper#executeIfPossible} (se gia' in esecuzione viene skippato,
+     * si trova solo nel log). Il suo esito non altera la response HTTP, che resta quella
+     * del primo job.
+     */
     @GetMapping("/run")
     public ResponseEntity<Object> eseguiJobEndpoint(
             @RequestParam(name = "force", required = false, defaultValue = "false") boolean force) {
-        return eseguiJob(force);
+        ResponseEntity<Object> notifyResponse = eseguiJob(force);
+        lanciaRtSendJobAsincrono();
+        return notifyResponse;
+    }
+
+    /**
+     * Lancia {@code rtSendJob} in background tramite
+     * {@link JobExecutionHelper#executeIfPossible}, che fa internamente il check di
+     * concorrenza multi-nodo. Eventuali eccezioni sono solo loggate: la risposta HTTP
+     * dell'endpoint resta quella del job primario.
+     */
+    private void lanciaRtSendJobAsincrono() {
+        CompletableFuture.runAsync(() -> {
+            try {
+                log.info("Lancio best-effort del job {}", Costanti.RT_SEND_JOB_NAME);
+                getJobExecutionHelper().executeIfPossible(rtSendJob, Costanti.RT_SEND_JOB_NAME);
+            } catch (Exception e) {
+                log.warn("Impossibile avviare {} dal controller: {}",
+                        Costanti.RT_SEND_JOB_NAME, e.getMessage(), e);
+            }
+        });
     }
 
     @GetMapping("/status")

--- a/src/main/java/it/govpay/notify/batch/entity/Notifica.java
+++ b/src/main/java/it/govpay/notify/batch/entity/Notifica.java
@@ -1,0 +1,72 @@
+package it.govpay.notify.batch.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Entity per la tabella {@code notifiche} di GovPay.
+ * <p>
+ * Replica la coda di spedizione del monolite: {@link StatoSpedizione#DA_SPEDIRE}
+ * + {@code data_prossima_spedizione < now} -> il record va inviato all'Ente.
+ * Allineata a {@code it.govpay.bd.model.Notifica} del monolite per i campi
+ * letti/aggiornati dal batch.
+ */
+@Entity
+@Table(name = "NOTIFICHE")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notifica {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_applicazione", nullable = false)
+    private Applicazione applicazione;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_rpt")
+    private Rpt rpt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_esito", nullable = false, length = 16)
+    private TipoNotifica tipoEsito;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "stato", nullable = false, length = 16)
+    private StatoSpedizione stato;
+
+    @Column(name = "descrizione_stato", length = 255)
+    private String descrizioneStato;
+
+    @Column(name = "tentativi_spedizione")
+    private Long tentativiSpedizione;
+
+    @Column(name = "data_creazione", nullable = false)
+    private LocalDateTime dataCreazione;
+
+    @Column(name = "data_aggiornamento_stato", nullable = false)
+    private LocalDateTime dataAggiornamentoStato;
+
+    @Column(name = "data_prossima_spedizione", nullable = false)
+    private LocalDateTime dataProssimaSpedizione;
+}

--- a/src/main/java/it/govpay/notify/batch/entity/Rpt.java
+++ b/src/main/java/it/govpay/notify/batch/entity/Rpt.java
@@ -1,0 +1,95 @@
+package it.govpay.notify.batch.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Entity per la tabella {@code rpt} di GovPay.
+ * <p>
+ * Sono mappati solo i campi necessari alla costruzione del payload
+ * {@code it.govpay.ec.client.beans.Ricevuta} (v2 EC API) e al lookup
+ * dei parametri della chiamata HTTP.
+ */
+@Entity
+@Table(name = "RPT")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Rpt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "cod_dominio", nullable = false, length = 35)
+    private String codDominio;
+
+    @Column(name = "iuv", nullable = false, length = 35)
+    private String iuv;
+
+    @Column(name = "ccp", nullable = false, length = 35)
+    private String ccp;
+
+    @Column(name = "cod_carrello", length = 35)
+    private String codCarrello;
+
+    @Column(name = "cod_sessione", length = 255)
+    private String codSessione;
+
+    @Column(name = "cod_sessione_portale", length = 255)
+    private String codSessionePortale;
+
+    @Column(name = "modello_pagamento", length = 16)
+    private String modelloPagamento;
+
+    @Column(name = "data_msg_ricevuta")
+    private LocalDateTime dataMsgRicevuta;
+
+    @Column(name = "cod_esito_pagamento")
+    private Integer codEsitoPagamento;
+
+    @Column(name = "importo_totale_pagato")
+    private BigDecimal importoTotalePagato;
+
+    @Column(name = "xml_rt")
+    private byte[] xmlRt;
+
+    @Column(name = "tipo_identificativo_attestante", length = 1)
+    private String tipoIdentificativoAttestante;
+
+    @Column(name = "identificativo_attestante", length = 35)
+    private String identificativoAttestante;
+
+    @Column(name = "denominazione_attestante", length = 70)
+    private String denominazioneAttestante;
+
+    @Column(name = "cod_psp", length = 35)
+    private String codPsp;
+
+    @Column(name = "cod_canale", length = 35)
+    private String codCanale;
+
+    @Column(name = "id_versamento", nullable = false)
+    private Long idVersamento;
+
+    /**
+     * Versione SANP della coppia RPT/RT (es. SANP_230, SANP_240, SANP_321_V2,
+     * RPTV1_RTV2, RPTV2_RTV1). Determina il {@code RicevutaRt.TipoEnum} nel
+     * payload v2 (CT_RICEVUTA_TELEMATICA per SANP_230, CT_RECEIPT altrimenti).
+     */
+    @Column(name = "versione", nullable = false, length = 35)
+    private String versione;
+}

--- a/src/main/java/it/govpay/notify/batch/entity/StatoSpedizione.java
+++ b/src/main/java/it/govpay/notify/batch/entity/StatoSpedizione.java
@@ -1,0 +1,11 @@
+package it.govpay.notify.batch.entity;
+
+/**
+ * Stato di spedizione di una notifica verso l'Ente.
+ * Allineato a {@code it.govpay.model.Notifica.StatoSpedizione} del monolite GovPay.
+ */
+public enum StatoSpedizione {
+    DA_SPEDIRE,
+    SPEDITO,
+    ANNULLATA
+}

--- a/src/main/java/it/govpay/notify/batch/entity/TipoNotifica.java
+++ b/src/main/java/it/govpay/notify/batch/entity/TipoNotifica.java
@@ -1,0 +1,12 @@
+package it.govpay.notify.batch.entity;
+
+/**
+ * Tipo di notifica inviata all'Ente.
+ * Allineato a {@code it.govpay.model.Notifica.TipoNotifica} del monolite GovPay.
+ */
+public enum TipoNotifica {
+    ATTIVAZIONE,
+    RICEVUTA,
+    ANNULLAMENTO,
+    FALLIMENTO
+}

--- a/src/main/java/it/govpay/notify/batch/repository/NotificheRepository.java
+++ b/src/main/java/it/govpay/notify/batch/repository/NotificheRepository.java
@@ -1,0 +1,91 @@
+package it.govpay.notify.batch.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import it.govpay.notify.batch.entity.Notifica;
+import it.govpay.notify.batch.entity.StatoSpedizione;
+import it.govpay.notify.batch.entity.TipoNotifica;
+
+/**
+ * Repository per la tabella {@code notifiche}. Replica la semantica di
+ * {@code it.govpay.bd.pagamento.NotificheBD} del monolite GovPay.
+ */
+@Repository
+public interface NotificheRepository extends JpaRepository<Notifica, Long> {
+
+    /**
+     * Ricerca le notifiche pronte alla spedizione: tipo specifico,
+     * stato {@link StatoSpedizione#DA_SPEDIRE} e
+     * {@code data_prossima_spedizione < dataLimite}. L'ordinamento per id
+     * garantisce stabilita' tra esecuzioni.
+     *
+     * @param tipoEsito tipo notifica da selezionare (RICEVUTA per il job RT)
+     * @param dataLimite valore con cui confrontare la data prossima spedizione (tipicamente {@code now})
+     * @param pageable paginazione applicata al reader del batch
+     */
+    @Query("SELECT n FROM Notifica n " +
+           "WHERE n.tipoEsito = :tipoEsito " +
+           "  AND n.stato = :stato " +
+           "  AND n.dataProssimaSpedizione < :dataLimite " +
+           "ORDER BY n.id ASC")
+    List<Notifica> findNotificheDaSpedire(@Param("tipoEsito") TipoNotifica tipoEsito,
+                                          @Param("stato") StatoSpedizione stato,
+                                          @Param("dataLimite") LocalDateTime dataLimite,
+                                          Pageable pageable);
+
+    /**
+     * Allinea {@code NotificheBD.updateSpedito(id)}: la notifica e' stata
+     * accettata dall'Ente.
+     */
+    @Modifying
+    @Query("UPDATE Notifica n SET " +
+           "n.stato = it.govpay.notify.batch.entity.StatoSpedizione.SPEDITO, " +
+           "n.descrizioneStato = NULL, " +
+           "n.dataAggiornamentoStato = :now " +
+           "WHERE n.id = :id")
+    int updateSpedito(@Param("id") Long id, @Param("now") LocalDateTime now);
+
+    /**
+     * Allinea {@code NotificheBD.updateDaSpedire}: errore non bloccante.
+     * Non sovrascrive lo stato (potrebbe essere stato chiuso da un altro nodo),
+     * aggiorna solo descrizione/tentativi/data prossima spedizione.
+     */
+    @Modifying
+    @Query("UPDATE Notifica n SET " +
+           "n.descrizioneStato = :descrizione, " +
+           "n.tentativiSpedizione = :tentativi, " +
+           "n.dataProssimaSpedizione = :prossima, " +
+           "n.dataAggiornamentoStato = :now " +
+           "WHERE n.id = :id")
+    int updateDaSpedire(@Param("id") Long id,
+                        @Param("descrizione") String descrizione,
+                        @Param("tentativi") Long tentativi,
+                        @Param("prossima") LocalDateTime prossima,
+                        @Param("now") LocalDateTime now);
+
+    /**
+     * Allinea {@code NotificheBD.updateAnnullata}: configurazione assente
+     * o errore terminale, la notifica non verra' piu' ripresa.
+     */
+    @Modifying
+    @Query("UPDATE Notifica n SET " +
+           "n.stato = it.govpay.notify.batch.entity.StatoSpedizione.ANNULLATA, " +
+           "n.descrizioneStato = :descrizione, " +
+           "n.tentativiSpedizione = :tentativi, " +
+           "n.dataProssimaSpedizione = :prossima, " +
+           "n.dataAggiornamentoStato = :now " +
+           "WHERE n.id = :id")
+    int updateAnnullata(@Param("id") Long id,
+                        @Param("descrizione") String descrizione,
+                        @Param("tentativi") Long tentativi,
+                        @Param("prossima") LocalDateTime prossima,
+                        @Param("now") LocalDateTime now);
+}

--- a/src/main/java/it/govpay/notify/batch/rt/config/RtSendJobConfiguration.java
+++ b/src/main/java/it/govpay/notify/batch/rt/config/RtSendJobConfiguration.java
@@ -1,0 +1,63 @@
+package it.govpay.notify.batch.rt.config;
+
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.job.parameters.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import it.govpay.notify.batch.Costanti;
+import it.govpay.notify.batch.rt.dto.NotificaContext;
+import it.govpay.notify.batch.rt.dto.RtSendResult;
+import it.govpay.notify.batch.rt.tasklet.RtSendProcessor;
+import it.govpay.notify.batch.rt.tasklet.RtSendReader;
+import it.govpay.notify.batch.rt.tasklet.RtSendWriter;
+
+/**
+ * Configurazione del job di spedizione delle notifiche RT.
+ * Job indipendente da {@code rtNotifyJob}: legge dalla tabella
+ * {@code notifiche} (tipo RICEVUTA, stato DA_SPEDIRE) e spedisce
+ * tramite il client OpenAPI {@code govpay-ec-client} v2.
+ */
+@Configuration
+public class RtSendJobConfiguration {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final int chunkSize;
+
+    public RtSendJobConfiguration(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            @Value("${govpay.batch.rt-send.chunk-size:50}") int chunkSize) {
+        this.jobRepository = jobRepository;
+        this.transactionManager = transactionManager;
+        this.chunkSize = chunkSize;
+    }
+
+    @Bean
+    public Job rtSendJob(Step rtSendStep) {
+        return new JobBuilder(Costanti.RT_SEND_JOB_NAME, jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(rtSendStep)
+                .build();
+    }
+
+    @Bean
+    public Step rtSendStep(
+            RtSendReader rtSendReader,
+            RtSendProcessor rtSendProcessor,
+            RtSendWriter rtSendWriter) {
+        return new StepBuilder("rtSendStep", jobRepository)
+                .<NotificaContext, RtSendResult>chunk(chunkSize, transactionManager)
+                .reader(rtSendReader)
+                .processor(rtSendProcessor)
+                .writer(rtSendWriter)
+                .build();
+    }
+}

--- a/src/main/java/it/govpay/notify/batch/rt/config/RtSendScheduledJobRunner.java
+++ b/src/main/java/it/govpay/notify/batch/rt/config/RtSendScheduledJobRunner.java
@@ -1,0 +1,50 @@
+package it.govpay.notify.batch.rt.config;
+
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.launch.JobRestartException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import it.govpay.common.batch.runner.AbstractScheduledJobRunner;
+import it.govpay.common.batch.runner.JobExecutionHelper;
+import it.govpay.notify.batch.Costanti;
+
+/**
+ * Runner per l'esecuzione schedulata del job di spedizione RT in modalita'
+ * multi-nodo. Attivo solo con profile "default" (non "cron") e quando
+ * {@code govpay.batch.rt-send.enabled=true}.
+ */
+@Component
+@Profile("default")
+@ConditionalOnProperty(name = "govpay.batch.rt-send.enabled", havingValue = "true", matchIfMissing = false)
+public class RtSendScheduledJobRunner extends AbstractScheduledJobRunner {
+
+    public RtSendScheduledJobRunner(
+            JobExecutionHelper jobExecutionHelper,
+            @Qualifier("rtSendJob") Job rtSendJob) {
+        super(jobExecutionHelper, rtSendJob, Costanti.RT_SEND_JOB_NAME);
+    }
+
+    /**
+     * Schedulazione cron, default {@code 0 * * * * *} (ogni minuto al secondo 0)
+     * per replicare il comportamento del monolite GovPay
+     * (cfr. {@code applicationContext-timers.xml}: {@code <task:scheduled
+     * cron="0 * * * * ?"/>} per la spedizione delle notifiche).
+     * <p>
+     * Se una run precedente e' ancora in corso (su questo o altro nodo), il
+     * dispatcher {@link it.govpay.common.batch.runner.JobExecutionHelper}
+     * salta l'esecuzione: non si verificano sovrapposizioni.
+     */
+    @Scheduled(cron = "${scheduler.rtSendJob.cron:0 * * * * *}")
+    public JobExecution runRtSendJob() throws JobExecutionAlreadyRunningException, JobRestartException,
+            JobInstanceAlreadyCompleteException, InvalidJobParametersException {
+        return executeScheduledJob();
+    }
+}

--- a/src/main/java/it/govpay/notify/batch/rt/dto/NotificaContext.java
+++ b/src/main/java/it/govpay/notify/batch/rt/dto/NotificaContext.java
@@ -1,0 +1,18 @@
+package it.govpay.notify.batch.rt.dto;
+
+import it.govpay.notify.batch.entity.Notifica;
+import it.govpay.notify.batch.entity.Rpt;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Coppia notifica + RPT passata dal reader al processor del job di spedizione RT.
+ * Mantenere le due entity insieme evita re-lookup nel processor e nel writer.
+ */
+@Data
+@Builder
+public class NotificaContext {
+
+    private final Notifica notifica;
+    private final Rpt rpt;
+}

--- a/src/main/java/it/govpay/notify/batch/rt/dto/RtSendOutcome.java
+++ b/src/main/java/it/govpay/notify/batch/rt/dto/RtSendOutcome.java
@@ -1,0 +1,15 @@
+package it.govpay.notify.batch.rt.dto;
+
+/**
+ * Esito della spedizione di una singola notifica RT.
+ * Determina quale update di stato applicare nel writer
+ * (cfr. {@code NotificheBD} del monolite).
+ */
+public enum RtSendOutcome {
+    /** HTTP 2xx -> updateSpedito */
+    SUCCESS,
+    /** Errore non bloccante (HTTP non 2xx, timeout, ecc.) -> updateDaSpedire con backoff */
+    ERROR,
+    /** Connettore non configurato o versione non supportata -> updateAnnullata */
+    ABORT
+}

--- a/src/main/java/it/govpay/notify/batch/rt/dto/RtSendResult.java
+++ b/src/main/java/it/govpay/notify/batch/rt/dto/RtSendResult.java
@@ -1,0 +1,28 @@
+package it.govpay.notify.batch.rt.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Risultato della spedizione prodotto dal processor e consumato dal writer.
+ * Contiene tutti i dati necessari ad applicare l'update di stato corretto.
+ */
+@Data
+@Builder
+public class RtSendResult {
+
+    /** Id della notifica (chiave primaria su tabella {@code notifiche}). */
+    private final Long notificaId;
+
+    /** Esito della spedizione. */
+    private final RtSendOutcome outcome;
+
+    /** Descrizione/messaggio di errore (null per {@link RtSendOutcome#SUCCESS}). */
+    private final String descrizione;
+
+    /**
+     * Valore aggiornato di {@code tentativi_spedizione} (= precedente + 1)
+     * per ERROR/ABORT; null per SUCCESS.
+     */
+    private final Long tentativiSpedizione;
+}

--- a/src/main/java/it/govpay/notify/batch/rt/service/EnteRicevutaApiService.java
+++ b/src/main/java/it/govpay/notify/batch/rt/service/EnteRicevutaApiService.java
@@ -1,0 +1,182 @@
+package it.govpay.notify.batch.rt.service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import it.govpay.common.client.model.Connettore;
+import it.govpay.common.client.service.ConnettoreService;
+import it.govpay.common.entity.ApplicazioneEntity;
+import it.govpay.common.repository.ApplicazioneRepository;
+import it.govpay.ec.client.api.NotificaRicevuteApi;
+import it.govpay.ec.client.api.impl.ApiClient;
+import it.govpay.ec.client.beans.Ricevuta;
+import it.govpay.notify.batch.Costanti;
+import it.govpay.notify.batch.config.EnteApiClientConfig;
+import it.govpay.notify.batch.entity.Notifica;
+import it.govpay.notify.batch.entity.Rpt;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service che spedisce le ricevute di pagamento (RT) all'API di integrazione
+ * dell'Ente, usando il client OpenAPI generato (v2 EC API:
+ * {@code PUT /ricevute/{idDominio}/{iuv}/{idRicevuta}}).
+ * <p>
+ * Versione del connettore letta da {@link ConnettoreService#getConnettoreAsMap}
+ * come workaround in attesa di un getter strong-typed su
+ * {@code Connettore} (vedi {@code docs/issues/govpay-common-versione-connettore.md}).
+ * <p>
+ * Solo la versione {@link Costanti#VERSIONE_API_EC_SUPPORTATA} e' supportata
+ * dalla PR corrente: altre versioni sollevano {@link UnsupportedOperationException},
+ * trattata dal writer come errore di spedizione standard (updateDaSpedire).
+ */
+@Slf4j
+@Service
+public class EnteRicevutaApiService {
+
+    private final ConnettoreService connettoreService;
+    private final ApplicazioneRepository applicazioneRepository;
+    private final RicevutaV2Mapper ricevutaV2Mapper;
+    private final ObjectMapper clientObjectMapper;
+    private final Duration connectTimeout;
+    private final Duration readTimeout;
+
+    private final ConcurrentHashMap<String, NotificaRicevuteApi> apiCache = new ConcurrentHashMap<>();
+
+    public EnteRicevutaApiService(
+            ConnettoreService connettoreService,
+            ApplicazioneRepository applicazioneRepository,
+            EnteApiClientConfig enteApiClientConfig,
+            RicevutaV2Mapper ricevutaV2Mapper,
+            @Value("${govpay.batch.rt-send.http.connect-timeout-ms:10000}") long connectTimeoutMs,
+            @Value("${govpay.batch.rt-send.http.read-timeout-ms:30000}") long readTimeoutMs) {
+        this.connettoreService = connettoreService;
+        this.applicazioneRepository = applicazioneRepository;
+        this.ricevutaV2Mapper = ricevutaV2Mapper;
+        this.clientObjectMapper = enteApiClientConfig.createEnteObjectMapper();
+        this.connectTimeout = Duration.ofMillis(connectTimeoutMs);
+        this.readTimeout = Duration.ofMillis(readTimeoutMs);
+    }
+
+    /**
+     * Spedisce la ricevuta all'API di integrazione dell'Ente.
+     *
+     * @throws IllegalStateException se l'applicazione o il connettore non sono configurati
+     * @throws UnsupportedOperationException se la versione del connettore non e' supportata
+     */
+    public ResponseEntity<Void> sendRicevuta(Notifica notifica, Rpt rpt) {
+        String codApplicazione = notifica.getApplicazione().getCodApplicazione();
+        String codConnettore = resolveConnectorCode(codApplicazione);
+        verificaVersioneSupportata(codConnettore);
+
+        NotificaRicevuteApi api = getOrCreateApi(codConnettore);
+        Ricevuta payload = ricevutaV2Mapper.toRicevuta(rpt);
+
+        log.debug("Spedizione ricevuta RT a {} (codDominio={}, iuv={}, ccp={})",
+                codApplicazione, rpt.getCodDominio(), rpt.getIuv(), rpt.getCcp());
+
+        return api.notificaRicevutaWithHttpInfo(
+                rpt.getCodDominio(),
+                rpt.getIuv(),
+                rpt.getCcp(),
+                rpt.getCodSessione(),
+                rpt.getCodSessionePortale(),
+                rpt.getCodCarrello(),
+                payload);
+    }
+
+    /**
+     * Svuota la cache delle istanze API. Da invocare se la configurazione di un
+     * connettore cambia a runtime.
+     */
+    public void clearCache() {
+        apiCache.clear();
+        connettoreService.clearCache();
+        log.info("Cache connettori RT svuotata");
+    }
+
+    private String resolveConnectorCode(String codApplicazione) {
+        Optional<ApplicazioneEntity> appOpt = applicazioneRepository.findByCodApplicazione(codApplicazione);
+        ApplicazioneEntity app = appOpt.orElseThrow(() -> new IllegalStateException(
+                "Nessuna applicazione trovata per il codice applicazione: " + codApplicazione));
+
+        String codConnettore = app.getCodConnettoreIntegrazione();
+        if (codConnettore == null || codConnettore.isBlank()) {
+            throw new IllegalStateException(
+                    "Connettore di integrazione non configurato per l'applicazione " + codApplicazione);
+        }
+        return codConnettore;
+    }
+
+    /**
+     * Verifica che il connettore sia configurato per la versione supportata.
+     * <p>
+     * Workaround temporaneo: la versione e' letta da
+     * {@link ConnettoreService#getConnettoreAsMap}. Dopo l'evoluzione di
+     * govpay-common (issue dedicata) sostituire con
+     * {@code connettoreService.getConnettore(code).getVersione()}.
+     */
+    private void verificaVersioneSupportata(String codConnettore) {
+        Map<String, String> props = connettoreService.getConnettoreAsMap(codConnettore);
+        if (props == null || props.isEmpty()) {
+            throw new IllegalStateException(
+                    "Connettore non configurato: " + codConnettore);
+        }
+        String versione = props.get(Costanti.CONNETTORE_PROPRIETA_VERSIONE);
+        if (!Costanti.VERSIONE_API_EC_SUPPORTATA.equals(versione)) {
+            throw new UnsupportedOperationException(
+                    "Versione EC API non supportata sul connettore " + codConnettore
+                            + ": atteso " + Costanti.VERSIONE_API_EC_SUPPORTATA
+                            + ", trovato " + versione);
+        }
+    }
+
+    private NotificaRicevuteApi getOrCreateApi(String codConnettore) {
+        return apiCache.computeIfAbsent(codConnettore, code -> {
+            RestTemplate restTemplate = connettoreService.getRestTemplate(code);
+            applicaTimeout(restTemplate);
+
+            MappingJackson2HttpMessageConverter converter =
+                    new MappingJackson2HttpMessageConverter(clientObjectMapper);
+            restTemplate.getMessageConverters().removeIf(MappingJackson2HttpMessageConverter.class::isInstance);
+            restTemplate.getMessageConverters().add(0, converter);
+
+            Connettore connettore = connettoreService.getConnettore(code);
+            ApiClient apiClient = new ApiClient(restTemplate);
+            apiClient.setBasePath(connettore.getUrl());
+
+            log.info("Creata istanza NotificaRicevuteApi per connettore {} (URL: {})", code, connettore.getUrl());
+            return new NotificaRicevuteApi(apiClient);
+        });
+    }
+
+    /**
+     * Applica i timeout da properties al {@link RestTemplate}. Per non perdere
+     * l'eventuale configurazione SSL/mTLS della {@link ClientHttpRequestFactory}
+     * costruita da govpay-common, si interviene solo su factory note
+     * (oggi solo il fallback non-SSL {@link SimpleClientHttpRequestFactory}).
+     * Negli altri casi si lascia invariato e si logga: i timeout vanno
+     * eventualmente configurati upstream (es. proprieta' del connettore).
+     */
+    private void applicaTimeout(RestTemplate restTemplate) {
+        ClientHttpRequestFactory factory = restTemplate.getRequestFactory();
+        if (factory instanceof SimpleClientHttpRequestFactory simple) {
+            simple.setConnectTimeout((int) connectTimeout.toMillis());
+            simple.setReadTimeout((int) readTimeout.toMillis());
+        } else {
+            log.debug("Timeout RT non applicati: ClientHttpRequestFactory non gestita ({})",
+                    factory.getClass().getName());
+        }
+    }
+}

--- a/src/main/java/it/govpay/notify/batch/rt/service/RicevutaV2Mapper.java
+++ b/src/main/java/it/govpay/notify/batch/rt/service/RicevutaV2Mapper.java
@@ -1,0 +1,100 @@
+package it.govpay.notify.batch.rt.service;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+import org.springframework.stereotype.Component;
+
+import it.govpay.ec.client.beans.Dominio;
+import it.govpay.ec.client.beans.EsitoRpp;
+import it.govpay.ec.client.beans.Ricevuta;
+import it.govpay.ec.client.beans.RicevutaIstitutoAttestante;
+import it.govpay.ec.client.beans.RicevutaRt;
+import it.govpay.notify.batch.entity.Rpt;
+
+/**
+ * Costruisce il payload {@link Ricevuta} v2 dell'EC API a partire dalla
+ * entity {@link Rpt}. Replica la semantica di
+ * {@code it.govpay.core.ec.v2.converter.RicevuteConverter} del monolite,
+ * limitatamente ai campi necessari alla spedizione (il batch non ha JAXB,
+ * quindi non valorizza il sotto-payload {@code rpt}/{@code rt.json} —
+ * solo l'XML grezzo dell'RT).
+ */
+@Component
+public class RicevutaV2Mapper {
+
+    private final ZoneId applicationZoneId;
+
+    public RicevutaV2Mapper(ZoneId applicationZoneId) {
+        this.applicationZoneId = applicationZoneId;
+    }
+
+    public Ricevuta toRicevuta(Rpt rpt) {
+        Ricevuta ricevuta = new Ricevuta();
+
+        Dominio dominio = new Dominio();
+        dominio.setIdDominio(rpt.getCodDominio());
+        ricevuta.setDominio(dominio);
+
+        ricevuta.setIuv(rpt.getIuv());
+        ricevuta.setIdRicevuta(rpt.getCcp());
+        ricevuta.setImporto(rpt.getImportoTotalePagato());
+        ricevuta.setEsito(toEsitoRpp(rpt.getCodEsitoPagamento()));
+
+        OffsetDateTime dataRicevuta = rpt.getDataMsgRicevuta() != null
+                ? rpt.getDataMsgRicevuta().atZone(applicationZoneId).toOffsetDateTime()
+                : null;
+        ricevuta.setData(dataRicevuta);
+        ricevuta.setDataPagamento(dataRicevuta);
+
+        if (rpt.getIdentificativoAttestante() != null) {
+            RicevutaIstitutoAttestante istituto = new RicevutaIstitutoAttestante();
+            istituto.setIdPSP(rpt.getIdentificativoAttestante());
+            istituto.setDenominazione(rpt.getDenominazioneAttestante());
+            istituto.setIdCanale(rpt.getCodCanale());
+            ricevuta.setIstitutoAttestante(istituto);
+        }
+
+        if (rpt.getXmlRt() != null) {
+            RicevutaRt ricevutaRt = new RicevutaRt();
+            ricevutaRt.setXml(rpt.getXmlRt());
+            ricevutaRt.setTipo(tipoRtFromVersione(rpt.getVersione()));
+            ricevuta.setRt(ricevutaRt);
+        }
+
+        return ricevuta;
+    }
+
+    /**
+     * Mappa il codice esito numerico (colonna {@code cod_esito_pagamento})
+     * sull'enum {@link EsitoRpp}. Codici da DDL govpay:
+     * 0=Eseguito, 1=Non eseguito, 2=Parzialmente eseguito,
+     * 3=Decorrenza, 4=Decorrenza parziale.
+     */
+    private EsitoRpp toEsitoRpp(Integer codEsito) {
+        if (codEsito == null) {
+            return null;
+        }
+        return switch (codEsito) {
+            case 0 -> EsitoRpp.ESEGUITO;
+            case 1 -> EsitoRpp.NON_ESEGUITO;
+            case 2 -> EsitoRpp.ESEGUITO_PARZIALE;
+            case 3 -> EsitoRpp.DECORRENZA;
+            case 4 -> EsitoRpp.DECORRENZA_PARZIALE;
+            default -> throw new IllegalArgumentException("Codice esito pagamento non riconosciuto: " + codEsito);
+        };
+    }
+
+    /**
+     * Sceglie il {@link RicevutaRt.TipoEnum} in funzione della versione SANP
+     * della RPT/RT (cfr. {@code RicevuteConverter} del monolite):
+     * SANP_230 -> CT_RICEVUTA_TELEMATICA; le altre (SANP_240, SANP_321_V2,
+     * RPTV1_RTV2, RPTV2_RTV1) -> CT_RECEIPT.
+     */
+    private RicevutaRt.TipoEnum tipoRtFromVersione(String versione) {
+        if ("SANP_230".equals(versione)) {
+            return RicevutaRt.TipoEnum.CT_RICEVUTA_TELEMATICA;
+        }
+        return RicevutaRt.TipoEnum.CT_RECEIPT;
+    }
+}

--- a/src/main/java/it/govpay/notify/batch/rt/tasklet/RtSendProcessor.java
+++ b/src/main/java/it/govpay/notify/batch/rt/tasklet/RtSendProcessor.java
@@ -1,0 +1,74 @@
+package it.govpay.notify.batch.rt.tasklet;
+
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+
+import it.govpay.notify.batch.Costanti;
+import it.govpay.notify.batch.entity.Notifica;
+import it.govpay.notify.batch.rt.dto.NotificaContext;
+import it.govpay.notify.batch.rt.dto.RtSendOutcome;
+import it.govpay.notify.batch.rt.dto.RtSendResult;
+import it.govpay.notify.batch.rt.service.EnteRicevutaApiService;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Processor che spedisce la singola notifica RT all'Ente e ne deriva
+ * il {@link RtSendResult} da applicare in scrittura.
+ */
+@Component
+@Slf4j
+public class RtSendProcessor implements ItemProcessor<NotificaContext, RtSendResult> {
+
+    private final EnteRicevutaApiService enteRicevutaApiService;
+
+    public RtSendProcessor(EnteRicevutaApiService enteRicevutaApiService) {
+        this.enteRicevutaApiService = enteRicevutaApiService;
+    }
+
+    @Override
+    public RtSendResult process(NotificaContext ctx) {
+        Notifica notifica = ctx.getNotifica();
+        long tentativiBase = notifica.getTentativiSpedizione() == null ? 0L : notifica.getTentativiSpedizione();
+
+        try {
+            ResponseEntity<Void> response = enteRicevutaApiService.sendRicevuta(notifica, ctx.getRpt());
+            log.debug("Ricevuta notificata: notificaId={}, status={}", notifica.getId(), response.getStatusCode());
+
+            return RtSendResult.builder()
+                    .notificaId(notifica.getId())
+                    .outcome(RtSendOutcome.SUCCESS)
+                    .build();
+
+        } catch (IllegalStateException | UnsupportedOperationException e) {
+            log.warn("Notifica RT annullata (notificaId={}): {}", notifica.getId(), e.getMessage());
+            return RtSendResult.builder()
+                    .notificaId(notifica.getId())
+                    .outcome(RtSendOutcome.ABORT)
+                    .descrizione(truncate(e.getMessage()))
+                    .tentativiSpedizione(tentativiBase + 1)
+                    .build();
+
+        } catch (RestClientException e) {
+            log.warn("Errore spedizione RT (notificaId={}): {}", notifica.getId(), e.getMessage());
+            return RtSendResult.builder()
+                    .notificaId(notifica.getId())
+                    .outcome(RtSendOutcome.ERROR)
+                    .descrizione(truncate(e.getMessage()))
+                    .tentativiSpedizione(tentativiBase + 1)
+                    .build();
+        }
+    }
+
+    private String truncate(String message) {
+        if (message == null) {
+            return null;
+        }
+        int max = Costanti.NOTIFICHE_DESCRIZIONE_STATO_MAX_LEN;
+        if (message.length() < max) {
+            return message;
+        }
+        return message.substring(0, max - 3) + "...";
+    }
+}

--- a/src/main/java/it/govpay/notify/batch/rt/tasklet/RtSendReader.java
+++ b/src/main/java/it/govpay/notify/batch/rt/tasklet/RtSendReader.java
@@ -1,0 +1,75 @@
+package it.govpay.notify.batch.rt.tasklet;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import it.govpay.notify.batch.entity.Notifica;
+import it.govpay.notify.batch.entity.StatoSpedizione;
+import it.govpay.notify.batch.entity.TipoNotifica;
+import it.govpay.notify.batch.repository.NotificheRepository;
+import it.govpay.notify.batch.rt.dto.NotificaContext;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reader paginato delle notifiche RICEVUTA pronte alla spedizione.
+ * Riproduce {@code NotificheBD.findNotificheDaSpedire} del monolite.
+ */
+@Component
+@StepScope
+@Slf4j
+public class RtSendReader implements ItemReader<NotificaContext> {
+
+    private final NotificheRepository notificheRepository;
+    private final int pageSize;
+
+    private List<NotificaContext> buffer;
+
+    public RtSendReader(NotificheRepository notificheRepository,
+                        @Value("${govpay.batch.rt-send.chunk-size:50}") int pageSize) {
+        this.notificheRepository = notificheRepository;
+        this.pageSize = pageSize;
+    }
+
+    @BeforeStep
+    public void init() {
+        this.buffer = null;
+    }
+
+    @Override
+    public NotificaContext read() {
+        if (buffer == null) {
+            loadBatch();
+        }
+        if (buffer.isEmpty()) {
+            return null;
+        }
+        return buffer.remove(0);
+    }
+
+    private void loadBatch() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Notifica> notifiche = notificheRepository.findNotificheDaSpedire(
+                TipoNotifica.RICEVUTA,
+                StatoSpedizione.DA_SPEDIRE,
+                now,
+                PageRequest.of(0, pageSize));
+
+        log.info("Trovate {} notifiche RT da spedire", notifiche.size());
+
+        buffer = new ArrayList<>(notifiche.size());
+        for (Notifica n : notifiche) {
+            buffer.add(NotificaContext.builder()
+                    .notifica(n)
+                    .rpt(n.getRpt())
+                    .build());
+        }
+    }
+}

--- a/src/main/java/it/govpay/notify/batch/rt/tasklet/RtSendWriter.java
+++ b/src/main/java/it/govpay/notify/batch/rt/tasklet/RtSendWriter.java
@@ -1,0 +1,81 @@
+package it.govpay.notify.batch.rt.tasklet;
+
+import java.time.LocalDateTime;
+
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import it.govpay.notify.batch.repository.NotificheRepository;
+import it.govpay.notify.batch.rt.dto.RtSendResult;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Writer del job RT. Applica l'aggiornamento di stato sulla tabella
+ * {@code notifiche} con una transazione per item, replicando i tre
+ * scenari del monolite ({@code NotificheBD}):
+ * <ul>
+ *   <li>SUCCESS -> updateSpedito</li>
+ *   <li>ERROR   -> updateDaSpedire con backoff quadratico (tentativi^2 * 60s, capped a 24h)</li>
+ *   <li>ABORT   -> updateAnnullata con data prossima spedizione "mai" (9999-02-01)</li>
+ * </ul>
+ */
+@Component
+@Slf4j
+public class RtSendWriter implements ItemWriter<RtSendResult> {
+
+    /** Sentinel "mai" usata anche dal monolite (cfr. InviaNotificaThread). */
+    private static final LocalDateTime DATA_PROSSIMA_SPEDIZIONE_MAI =
+            LocalDateTime.of(9999, 2, 1, 0, 0);
+
+    private static final long ONE_DAY_SECONDS = 24L * 60 * 60;
+
+    private final NotificheRepository notificheRepository;
+
+    public RtSendWriter(NotificheRepository notificheRepository) {
+        this.notificheRepository = notificheRepository;
+    }
+
+    @Override
+    public void write(Chunk<? extends RtSendResult> chunk) {
+        for (RtSendResult r : chunk) {
+            if (r == null) {
+                continue;
+            }
+            applyUpdate(r);
+        }
+    }
+
+    /**
+     * Update di stato della singola notifica in transazione propria
+     * (REQUIRES_NEW): se la riga successiva fallisce, le precedenti
+     * restano committate.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void applyUpdate(RtSendResult r) {
+        LocalDateTime now = LocalDateTime.now();
+        switch (r.getOutcome()) {
+            case SUCCESS -> notificheRepository.updateSpedito(r.getNotificaId(), now);
+            case ERROR -> {
+                LocalDateTime prossima = nextRetry(now, r.getTentativiSpedizione());
+                notificheRepository.updateDaSpedire(r.getNotificaId(),
+                        r.getDescrizione(), r.getTentativiSpedizione(), prossima, now);
+            }
+            case ABORT -> notificheRepository.updateAnnullata(r.getNotificaId(),
+                    r.getDescrizione(), r.getTentativiSpedizione(),
+                    DATA_PROSSIMA_SPEDIZIONE_MAI, now);
+        }
+        log.debug("Aggiornato stato notifica RT id={} outcome={}", r.getNotificaId(), r.getOutcome());
+    }
+
+    /**
+     * Backoff quadratico: {@code now + tentativi^2 * 60s}, capped a 24h
+     * (cfr. {@code InviaNotificaThread} del monolite).
+     */
+    private LocalDateTime nextRetry(LocalDateTime now, Long tentativi) {
+        long delaySeconds = Math.min(tentativi * tentativi * 60L, ONE_DAY_SECONDS);
+        return now.plusSeconds(delaySeconds);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,18 @@ scheduler.rtNotifyJob.fixedDelayString=7200000
 # Initial delay before first execution (in milliseconds) - default 1ms
 scheduler.initialDelayString=1
 
+# === Job di spedizione notifiche RT verso API di integrazione Ente ===
+# Feature flag: attiva lo scheduling del job RT (default disabilitato).
+govpay.batch.rt-send.enabled=false
+# Dimensione chunk reader/processor/writer.
+govpay.batch.rt-send.chunk-size=50
+# Timeout HTTP applicati al RestTemplate del client EC (millisecondi).
+govpay.batch.rt-send.http.connect-timeout-ms=10000
+govpay.batch.rt-send.http.read-timeout-ms=30000
+# Scheduler dedicato al job RT (cron Spring a 6 campi: sec min hour dom month dow).
+# Default ogni minuto al secondo 0, in linea con il monolite GovPay.
+scheduler.rtSendJob.cron=0 * * * * *
+
 # Actuator configuration
 management.endpoints.web.base-path=/actuator
 management.endpoints.web.exposure.include=health,info,metrics

--- a/src/test/java/it/govpay/notify/batch/unit/controller/BatchControllerTest.java
+++ b/src/test/java/it/govpay/notify/batch/unit/controller/BatchControllerTest.java
@@ -29,6 +29,7 @@ class BatchControllerTest {
     private JobExecutionHelper jobExecutionHelper;
     private JobRepository jobRepository;
     private Job rtNotifyJob;
+    private Job rtSendJob;
     private EnteApiService enteApiService;
     private Environment environment;
     private ZoneId applicationZoneId;
@@ -40,6 +41,7 @@ class BatchControllerTest {
         jobExecutionHelper = mock(JobExecutionHelper.class);
         jobRepository = mock(JobRepository.class);
         rtNotifyJob = mock(Job.class);
+        rtSendJob = mock(Job.class);
         enteApiService = mock(EnteApiService.class);
         environment = mock(Environment.class);
         applicationZoneId = ZoneId.of("Europe/Rome");
@@ -48,6 +50,7 @@ class BatchControllerTest {
                 jobExecutionHelper,
                 jobRepository,
                 rtNotifyJob,
+                rtSendJob,
                 enteApiService,
                 environment,
                 applicationZoneId,
@@ -99,6 +102,19 @@ class BatchControllerTest {
     @DisplayName("eseguiJobEndpoint returns a non-null response (force=true)")
     void eseguiJobEndpointForceReturnsResponse() {
         assertNotNull(controller.eseguiJobEndpoint(true));
+    }
+
+    @Test
+    @DisplayName("eseguiJobEndpoint avvia anche rtSendJob in modalita' best-effort")
+    void eseguiJobEndpointAlsoTriggersRtSendJob() throws Exception {
+        controller.eseguiJobEndpoint(false);
+
+        // executeIfPossible(rtSendJob, "rtSendJob") gira async sul ForkJoinPool.commonPool().
+        // Aspettiamo che la chiamata venga registrata (max ~2s) per evitare flakiness.
+        org.awaitility.Awaitility.await()
+                .atMost(java.time.Duration.ofSeconds(2))
+                .untilAsserted(() ->
+                        verify(jobExecutionHelper).executeIfPossible(rtSendJob, Costanti.RT_SEND_JOB_NAME));
     }
 
     @Test

--- a/src/test/java/it/govpay/notify/batch/unit/rt/EnteRicevutaApiServiceTest.java
+++ b/src/test/java/it/govpay/notify/batch/unit/rt/EnteRicevutaApiServiceTest.java
@@ -1,0 +1,108 @@
+package it.govpay.notify.batch.unit.rt;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import it.govpay.common.client.service.ConnettoreService;
+import it.govpay.common.entity.ApplicazioneEntity;
+import it.govpay.common.repository.ApplicazioneRepository;
+import it.govpay.notify.batch.config.EnteApiClientConfig;
+import it.govpay.notify.batch.entity.Applicazione;
+import it.govpay.notify.batch.entity.Notifica;
+import it.govpay.notify.batch.entity.Rpt;
+import it.govpay.notify.batch.rt.service.EnteRicevutaApiService;
+import it.govpay.notify.batch.rt.service.RicevutaV2Mapper;
+
+@DisplayName("EnteRicevutaApiService - validazioni precondizioni")
+class EnteRicevutaApiServiceTest {
+
+    private ConnettoreService connettoreService;
+    private ApplicazioneRepository applicazioneRepository;
+    private RicevutaV2Mapper mapper;
+    private EnteRicevutaApiService service;
+
+    @BeforeEach
+    void setUp() {
+        connettoreService = mock(ConnettoreService.class);
+        applicazioneRepository = mock(ApplicazioneRepository.class);
+        mapper = mock(RicevutaV2Mapper.class);
+
+        EnteApiClientConfig config = new EnteApiClientConfig();
+        // valore minimo necessario per createEnteObjectMapper
+        org.springframework.test.util.ReflectionTestUtils.setField(config, "timezone", "Europe/Rome");
+
+        service = new EnteRicevutaApiService(connettoreService, applicazioneRepository,
+                config, mapper, 1000L, 1000L);
+    }
+
+    private Notifica notificaFor(String codApplicazione) {
+        return Notifica.builder()
+                .id(1L)
+                .applicazione(Applicazione.builder().codApplicazione(codApplicazione).build())
+                .build();
+    }
+
+    @Test
+    @DisplayName("applicazione assente -> IllegalStateException")
+    void applicationMissing() {
+        when(applicazioneRepository.findByCodApplicazione(any())).thenReturn(Optional.empty());
+        assertThrows(IllegalStateException.class,
+                () -> service.sendRicevuta(notificaFor("APP1"), Rpt.builder().build()));
+    }
+
+    @Test
+    @DisplayName("codConnettoreIntegrazione assente -> IllegalStateException")
+    void connectorCodeMissing() {
+        when(applicazioneRepository.findByCodApplicazione("APP1"))
+                .thenReturn(Optional.of(ApplicazioneEntity.builder()
+                        .codApplicazione("APP1")
+                        .codConnettoreIntegrazione(null)
+                        .build()));
+        assertThrows(IllegalStateException.class,
+                () -> service.sendRicevuta(notificaFor("APP1"), Rpt.builder().build()));
+    }
+
+    @Test
+    @DisplayName("connettore non configurato (map vuota) -> IllegalStateException")
+    void connectorPropsEmpty() {
+        when(applicazioneRepository.findByCodApplicazione("APP1"))
+                .thenReturn(Optional.of(ApplicazioneEntity.builder()
+                        .codApplicazione("APP1").codConnettoreIntegrazione("CONN1").build()));
+        when(connettoreService.getConnettoreAsMap("CONN1")).thenReturn(Map.of());
+        assertThrows(IllegalStateException.class,
+                () -> service.sendRicevuta(notificaFor("APP1"), Rpt.builder().build()));
+    }
+
+    @Test
+    @DisplayName("VERSIONE != REST_2 -> UnsupportedOperationException")
+    void unsupportedVersion() {
+        when(applicazioneRepository.findByCodApplicazione("APP1"))
+                .thenReturn(Optional.of(ApplicazioneEntity.builder()
+                        .codApplicazione("APP1").codConnettoreIntegrazione("CONN1").build()));
+        when(connettoreService.getConnettoreAsMap("CONN1"))
+                .thenReturn(Map.of("VERSIONE", "REST_1"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> service.sendRicevuta(notificaFor("APP1"), Rpt.builder().build()));
+    }
+
+    @Test
+    @DisplayName("VERSIONE assente nella map -> UnsupportedOperationException")
+    void missingVersion() {
+        when(applicazioneRepository.findByCodApplicazione("APP1"))
+                .thenReturn(Optional.of(ApplicazioneEntity.builder()
+                        .codApplicazione("APP1").codConnettoreIntegrazione("CONN1").build()));
+        when(connettoreService.getConnettoreAsMap("CONN1"))
+                .thenReturn(Map.of("URL", "https://ente.example.com"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> service.sendRicevuta(notificaFor("APP1"), Rpt.builder().build()));
+    }
+}

--- a/src/test/java/it/govpay/notify/batch/unit/rt/RicevutaV2MapperTest.java
+++ b/src/test/java/it/govpay/notify/batch/unit/rt/RicevutaV2MapperTest.java
@@ -1,0 +1,130 @@
+package it.govpay.notify.batch.unit.rt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import it.govpay.ec.client.beans.EsitoRpp;
+import it.govpay.ec.client.beans.Ricevuta;
+import it.govpay.ec.client.beans.RicevutaRt;
+import it.govpay.notify.batch.entity.Rpt;
+import it.govpay.notify.batch.rt.service.RicevutaV2Mapper;
+
+@DisplayName("RicevutaV2Mapper")
+class RicevutaV2MapperTest {
+
+    private RicevutaV2Mapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new RicevutaV2Mapper(ZoneId.of("Europe/Rome"));
+    }
+
+    private Rpt baseRpt() {
+        return Rpt.builder()
+                .id(1L)
+                .codDominio("12345678901")
+                .iuv("01234567890123456")
+                .ccp("CCP-TEST")
+                .codSessione("sess-1")
+                .codSessionePortale("portale-1")
+                .codCarrello("carrello-1")
+                .modelloPagamento("1")
+                .dataMsgRicevuta(LocalDateTime.of(2026, 6, 1, 10, 30))
+                .codEsitoPagamento(0)
+                .importoTotalePagato(new BigDecimal("12.34"))
+                .xmlRt("<rt/>".getBytes())
+                .tipoIdentificativoAttestante("B")
+                .identificativoAttestante("BNLIITRR")
+                .denominazioneAttestante("BNL")
+                .codPsp("PSP-1")
+                .codCanale("CANALE-1")
+                .idVersamento(99L)
+                .versione("SANP_321_V2")
+                .build();
+    }
+
+    @Test
+    @DisplayName("mappa i campi base, l'istituto attestante e il body RT (CT_RECEIPT)")
+    void mapsAllFields() {
+        Ricevuta r = mapper.toRicevuta(baseRpt());
+
+        assertNotNull(r.getDominio());
+        assertEquals("12345678901", r.getDominio().getIdDominio());
+        assertEquals("01234567890123456", r.getIuv());
+        assertEquals("CCP-TEST", r.getIdRicevuta());
+        assertEquals(new BigDecimal("12.34"), r.getImporto());
+        assertEquals(EsitoRpp.ESEGUITO, r.getEsito());
+        assertNotNull(r.getData());
+        assertEquals(r.getData(), r.getDataPagamento());
+
+        assertNotNull(r.getIstitutoAttestante());
+        assertEquals("BNLIITRR", r.getIstitutoAttestante().getIdPSP());
+        assertEquals("BNL", r.getIstitutoAttestante().getDenominazione());
+        assertEquals("CANALE-1", r.getIstitutoAttestante().getIdCanale());
+
+        assertNotNull(r.getRt());
+        assertEquals(RicevutaRt.TipoEnum.CT_RECEIPT, r.getRt().getTipo());
+        assertNotNull(r.getRt().getXml());
+    }
+
+    @Test
+    @DisplayName("SANP_230 produce un RT con tipo CT_RICEVUTA_TELEMATICA")
+    void sanp230ToCtRicevutaTelematica() {
+        Rpt rpt = baseRpt();
+        rpt.setVersione("SANP_230");
+        Ricevuta r = mapper.toRicevuta(rpt);
+        assertEquals(RicevutaRt.TipoEnum.CT_RICEVUTA_TELEMATICA, r.getRt().getTipo());
+    }
+
+    @Test
+    @DisplayName("xml RT assente -> body RT non valorizzato")
+    void noXmlRtNoRtBody() {
+        Rpt rpt = baseRpt();
+        rpt.setXmlRt(null);
+        Ricevuta r = mapper.toRicevuta(rpt);
+        assertNull(r.getRt());
+    }
+
+    @Test
+    @DisplayName("identificativo attestante assente -> istituto attestante non valorizzato")
+    void noAttestanteNoIstituto() {
+        Rpt rpt = baseRpt();
+        rpt.setIdentificativoAttestante(null);
+        Ricevuta r = mapper.toRicevuta(rpt);
+        assertNull(r.getIstitutoAttestante());
+    }
+
+    @Test
+    @DisplayName("codice esito non riconosciuto solleva IllegalArgumentException")
+    void unknownEsito() {
+        Rpt rpt = baseRpt();
+        rpt.setCodEsitoPagamento(99);
+        assertThrows(IllegalArgumentException.class, () -> mapper.toRicevuta(rpt));
+    }
+
+    @Test
+    @DisplayName("esiti 0..4 mappati 1-a-1 su EsitoRpp")
+    void allKnownEsiti() {
+        assertEquals(EsitoRpp.ESEGUITO, mapEsito(0));
+        assertEquals(EsitoRpp.NON_ESEGUITO, mapEsito(1));
+        assertEquals(EsitoRpp.ESEGUITO_PARZIALE, mapEsito(2));
+        assertEquals(EsitoRpp.DECORRENZA, mapEsito(3));
+        assertEquals(EsitoRpp.DECORRENZA_PARZIALE, mapEsito(4));
+    }
+
+    private EsitoRpp mapEsito(int code) {
+        Rpt rpt = baseRpt();
+        rpt.setCodEsitoPagamento(code);
+        return mapper.toRicevuta(rpt).getEsito();
+    }
+}

--- a/src/test/java/it/govpay/notify/batch/unit/rt/RtSendProcessorTest.java
+++ b/src/test/java/it/govpay/notify/batch/unit/rt/RtSendProcessorTest.java
@@ -1,0 +1,108 @@
+package it.govpay.notify.batch.unit.rt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpServerErrorException;
+
+import it.govpay.notify.batch.entity.Applicazione;
+import it.govpay.notify.batch.entity.Notifica;
+import it.govpay.notify.batch.entity.Rpt;
+import it.govpay.notify.batch.rt.dto.NotificaContext;
+import it.govpay.notify.batch.rt.dto.RtSendOutcome;
+import it.govpay.notify.batch.rt.dto.RtSendResult;
+import it.govpay.notify.batch.rt.service.EnteRicevutaApiService;
+import it.govpay.notify.batch.rt.tasklet.RtSendProcessor;
+
+@DisplayName("RtSendProcessor")
+class RtSendProcessorTest {
+
+    private EnteRicevutaApiService service;
+    private RtSendProcessor processor;
+    private NotificaContext ctx;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(EnteRicevutaApiService.class);
+        processor = new RtSendProcessor(service);
+
+        Notifica notifica = Notifica.builder()
+                .id(42L)
+                .tentativiSpedizione(2L)
+                .applicazione(Applicazione.builder().codApplicazione("APP1").build())
+                .build();
+        Rpt rpt = Rpt.builder().id(7L).codDominio("DOM").iuv("IUV").ccp("CCP").build();
+        ctx = NotificaContext.builder().notifica(notifica).rpt(rpt).build();
+    }
+
+    @Test
+    @DisplayName("HTTP 2xx -> outcome SUCCESS, no descrizione, no tentativi")
+    void success() {
+        when(service.sendRicevuta(any(), any())).thenReturn(ResponseEntity.status(HttpStatus.CREATED).build());
+
+        RtSendResult r = processor.process(ctx);
+
+        assertNotNull(r);
+        assertEquals(42L, r.getNotificaId());
+        assertEquals(RtSendOutcome.SUCCESS, r.getOutcome());
+        assertNull(r.getDescrizione());
+        assertNull(r.getTentativiSpedizione());
+    }
+
+    @Test
+    @DisplayName("RestClientException -> outcome ERROR, tentativi+1, descrizione troncata")
+    void error() {
+        when(service.sendRicevuta(any(), any()))
+                .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "boom"));
+
+        RtSendResult r = processor.process(ctx);
+
+        assertEquals(RtSendOutcome.ERROR, r.getOutcome());
+        assertEquals(3L, r.getTentativiSpedizione());
+        assertNotNull(r.getDescrizione());
+    }
+
+    @Test
+    @DisplayName("UnsupportedOperationException (versione) -> outcome ABORT")
+    void abortVersione() {
+        when(service.sendRicevuta(any(), any()))
+                .thenThrow(new UnsupportedOperationException("versione REST_1 non supportata"));
+
+        RtSendResult r = processor.process(ctx);
+
+        assertEquals(RtSendOutcome.ABORT, r.getOutcome());
+        assertEquals(3L, r.getTentativiSpedizione());
+    }
+
+    @Test
+    @DisplayName("IllegalStateException (connettore assente) -> outcome ABORT")
+    void abortConnettore() {
+        when(service.sendRicevuta(any(), any()))
+                .thenThrow(new IllegalStateException("connettore non configurato"));
+
+        RtSendResult r = processor.process(ctx);
+
+        assertEquals(RtSendOutcome.ABORT, r.getOutcome());
+    }
+
+    @Test
+    @DisplayName("tentativi a null sulla notifica viene trattato come 0 di base")
+    void tentativiNull() {
+        ctx.getNotifica().setTentativiSpedizione(null);
+        when(service.sendRicevuta(any(), any()))
+                .thenThrow(new HttpServerErrorException(HttpStatus.SERVICE_UNAVAILABLE, "503"));
+
+        RtSendResult r = processor.process(ctx);
+
+        assertEquals(1L, r.getTentativiSpedizione());
+    }
+}

--- a/src/test/java/it/govpay/notify/batch/unit/rt/RtSendWriterTest.java
+++ b/src/test/java/it/govpay/notify/batch/unit/rt/RtSendWriterTest.java
@@ -1,0 +1,119 @@
+package it.govpay.notify.batch.unit.rt;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.batch.infrastructure.item.Chunk;
+
+import it.govpay.notify.batch.repository.NotificheRepository;
+import it.govpay.notify.batch.rt.dto.RtSendOutcome;
+import it.govpay.notify.batch.rt.dto.RtSendResult;
+import it.govpay.notify.batch.rt.tasklet.RtSendWriter;
+
+@DisplayName("RtSendWriter")
+class RtSendWriterTest {
+
+    private NotificheRepository repo;
+    private RtSendWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(NotificheRepository.class);
+        writer = new RtSendWriter(repo);
+    }
+
+    @Test
+    @DisplayName("SUCCESS -> updateSpedito; gli altri update non vengono chiamati")
+    void success() {
+        RtSendResult r = RtSendResult.builder()
+                .notificaId(10L)
+                .outcome(RtSendOutcome.SUCCESS)
+                .build();
+
+        writer.write(new Chunk<>(java.util.List.of(r)));
+
+        verify(repo).updateSpedito(eq(10L), any(LocalDateTime.class));
+        verify(repo, never()).updateDaSpedire(any(), any(), any(), any(), any());
+        verify(repo, never()).updateAnnullata(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("ABORT -> updateAnnullata con sentinel \"mai\" (9999-02-01)")
+    void abort() {
+        RtSendResult r = RtSendResult.builder()
+                .notificaId(11L)
+                .outcome(RtSendOutcome.ABORT)
+                .descrizione("connettore assente")
+                .tentativiSpedizione(1L)
+                .build();
+
+        writer.write(new Chunk<>(java.util.List.of(r)));
+
+        ArgumentCaptor<LocalDateTime> prossima = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(repo).updateAnnullata(eq(11L), eq("connettore assente"), eq(1L),
+                prossima.capture(), any(LocalDateTime.class));
+        org.junit.jupiter.api.Assertions.assertEquals(
+                LocalDateTime.of(9999, 2, 1, 0, 0), prossima.getValue());
+    }
+
+    @Test
+    @DisplayName("ERROR -> updateDaSpedire con backoff quadratico (tentativi^2 * 60s)")
+    void errorBackoff() {
+        RtSendResult r = RtSendResult.builder()
+                .notificaId(12L)
+                .outcome(RtSendOutcome.ERROR)
+                .descrizione("HTTP 503")
+                .tentativiSpedizione(3L) // 3^2 * 60s = 540s
+                .build();
+
+        LocalDateTime before = LocalDateTime.now();
+        writer.write(new Chunk<>(java.util.List.of(r)));
+
+        ArgumentCaptor<LocalDateTime> prossima = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(repo).updateDaSpedire(eq(12L), eq("HTTP 503"), eq(3L),
+                prossima.capture(), any(LocalDateTime.class));
+        long secs = java.time.Duration.between(before, prossima.getValue()).toSeconds();
+        org.junit.jupiter.api.Assertions.assertTrue(secs >= 539 && secs <= 541,
+                "atteso ~540s, ottenuto " + secs);
+    }
+
+    @Test
+    @DisplayName("ERROR con molti tentativi -> backoff capped a 24h")
+    void errorBackoffCapped() {
+        RtSendResult r = RtSendResult.builder()
+                .notificaId(13L)
+                .outcome(RtSendOutcome.ERROR)
+                .descrizione("HTTP 500")
+                .tentativiSpedizione(1000L) // 1000^2 * 60s = 16.6 anni -> cap 24h
+                .build();
+
+        LocalDateTime before = LocalDateTime.now();
+        writer.write(new Chunk<>(java.util.List.of(r)));
+
+        ArgumentCaptor<LocalDateTime> prossima = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(repo).updateDaSpedire(eq(13L), any(), eq(1000L),
+                prossima.capture(), any(LocalDateTime.class));
+        long secs = java.time.Duration.between(before, prossima.getValue()).toSeconds();
+        org.junit.jupiter.api.Assertions.assertTrue(secs <= 24L * 60 * 60 + 1,
+                "atteso <= 24h, ottenuto " + secs);
+    }
+
+    @Test
+    @DisplayName("Chunk con elementi null saltati")
+    void nullsSkipped() {
+        java.util.List<RtSendResult> list = new java.util.ArrayList<>();
+        list.add(null);
+        list.add(RtSendResult.builder().notificaId(14L).outcome(RtSendOutcome.SUCCESS).build());
+        writer.write(new Chunk<>(list));
+        verify(repo).updateSpedito(eq(14L), any(LocalDateTime.class));
+    }
+}


### PR DESCRIPTION
…pagamento (RT) all'API di integrazione dell'Ente.

Nuovo job batch indipendente rtSendJob, separato dal job rendicontazioni, allineato al monolite GovPay (NotificheBD + InviaNotificaThread + RicevuteConverter):
- reader paginato sulla tabella notifiche (tipo_esito=RICEVUTA, stato=DA_SPEDIRE, data_prossima_spedizione<now);
- processor che spedisce via govpay-ec-client 2.0.0-SNAPSHOT (NotificaRicevuteApi, v2 EC API: PUT /ricevute/{idDominio}/{iuv}/{idRicevuta});
- writer in transazione per item con tre transizioni di stato: SUCCESS->updateSpedito, ERROR->updateDaSpedire con backoff quadratico (tentativi^2*60s capped a 24h), ABORT->updateAnnullata con sentinel "mai" (9999-02-01).

Schedulazione cron Spring (default 0 * * * * *, ogni minuto al secondo 0) per replicare il comportamento del monolite (le notifiche venivano inserite nella coda alla ricezione della RT e spedite entro un minuto). Runner @Profile("default") protetto da feature flag govpay.batch.rt-send.enabled=false di default.

RicevutaV2Mapper popola il payload Ricevuta v2 con i campi disponibili in DB: dominio, iuv, idRicevuta, importo, esito, data/dataPagamento, istitutoAttestante, rt (xml grezzo + tipo CT_RICEVUTA_TELEMATICA per SANP_230 / CT_RECEIPT altrimenti). Solo la v2 dell'EC API e' supportata: connettori configurati su versioni diverse vengono trattati come ABORT (notifica annullata).

Predisposta issue per esporre la versione del connettore su govpay-common in modo strong-typed (docs/issues/govpay-common-versione-connettore.md); workaround temporaneo: lettura via ConnettoreService.getConnettoreAsMap.

Timeout HTTP del client EC letti da properties (govpay.batch.rt-send.http.connect-timeout-ms / read-timeout-ms).

BatchController esteso: l'endpoint /api/batch/run ora lancia, oltre al rtNotifyJob preesistente, anche rtSendJob in modo asincrono best-effort (CompletableFuture.runAsync su JobExecutionHelper.executeIfPossible). La response HTTP resta quella del job primario; eventuali skip per concorrenza del secondo job sono solo loggati.