### PR TITLE
govpay.batch.rt-send.enabled diventa kill switch effettivo sulla sped…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-06-15  Giuliano Pintori <pintori@link.it>
+
+	* [Feature]
+	La proprieta' govpay.batch.rt-send.enabled (default false) diventa kill switch effettivo sulla spedizione RT, non solo sullo scheduler. Quando disabilitata: il runner schedulato non viene istanziato (@ConditionalOnProperty come prima) e il BatchController salta anche il lancio best-effort di rtSendJob dall'endpoint /api/batch/run. Quando abilitata: il job parte sia da cron sia da API. Aggiornato il commento descrittivo in application.properties.
+
 2026-06-09  Giuliano Pintori <pintori@link.it>
 
 	* [Feature]

--- a/src/main/java/it/govpay/notify/batch/controller/BatchController.java
+++ b/src/main/java/it/govpay/notify/batch/controller/BatchController.java
@@ -33,6 +33,7 @@ public class BatchController extends AbstractBatchController {
 
     private final Job rtNotifyJob;
     private final Job rtSendJob;
+    private final boolean rtSendEnabled;
     private final EnteApiService enteApiService;
 
     public BatchController(
@@ -43,10 +44,12 @@ public class BatchController extends AbstractBatchController {
             EnteApiService enteApiService,
             Environment environment,
             ZoneId applicationZoneId,
-            @Value("${scheduler.rtNotifyJob.fixedDelayString:7200000}") long schedulerIntervalMillis) {
+            @Value("${scheduler.rtNotifyJob.fixedDelayString:7200000}") long schedulerIntervalMillis,
+            @Value("${govpay.batch.rt-send.enabled:false}") boolean rtSendEnabled) {
         super(jobExecutionHelper, jobRepository, environment, applicationZoneId, schedulerIntervalMillis);
         this.rtNotifyJob = rtNotifyJob;
         this.rtSendJob = rtSendJob;
+        this.rtSendEnabled = rtSendEnabled;
         this.enteApiService = enteApiService;
     }
 
@@ -92,8 +95,17 @@ public class BatchController extends AbstractBatchController {
      * {@link JobExecutionHelper#executeIfPossible}, che fa internamente il check di
      * concorrenza multi-nodo. Eventuali eccezioni sono solo loggate: la risposta HTTP
      * dell'endpoint resta quella del job primario.
+     * <p>
+     * Rispetta la feature flag {@code govpay.batch.rt-send.enabled}: se {@code false},
+     * il job non viene lanciato (kill switch coerente con il runner schedulato, che
+     * tramite {@code @ConditionalOnProperty} non viene nemmeno istanziato).
      */
     private void lanciaRtSendJobAsincrono() {
+        if (!rtSendEnabled) {
+            log.debug("Spedizione RT disabilitata (govpay.batch.rt-send.enabled=false): {} non avviato",
+                    Costanti.RT_SEND_JOB_NAME);
+            return;
+        }
         CompletableFuture.runAsync(() -> {
             try {
                 log.info("Lancio best-effort del job {}", Costanti.RT_SEND_JOB_NAME);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,7 +30,10 @@ scheduler.rtNotifyJob.fixedDelayString=7200000
 scheduler.initialDelayString=1
 
 # === Job di spedizione notifiche RT verso API di integrazione Ente ===
-# Feature flag: attiva lo scheduling del job RT (default disabilitato).
+# Kill switch globale per la spedizione RT (default disabilitato).
+# - Se false: il runner schedulato non viene istanziato (@ConditionalOnProperty)
+#   e il BatchController salta il lancio best-effort dall'endpoint /api/batch/run.
+# - Se true: il job rtSendJob parte sia da cron sia da API.
 govpay.batch.rt-send.enabled=false
 # Dimensione chunk reader/processor/writer.
 govpay.batch.rt-send.chunk-size=50

--- a/src/test/java/it/govpay/notify/batch/unit/controller/BatchControllerTest.java
+++ b/src/test/java/it/govpay/notify/batch/unit/controller/BatchControllerTest.java
@@ -46,7 +46,11 @@ class BatchControllerTest {
         environment = mock(Environment.class);
         applicationZoneId = ZoneId.of("Europe/Rome");
 
-        controller = new BatchController(
+        controller = buildController(true);
+    }
+
+    private BatchController buildController(boolean rtSendEnabled) {
+        return new BatchController(
                 jobExecutionHelper,
                 jobRepository,
                 rtNotifyJob,
@@ -54,7 +58,8 @@ class BatchControllerTest {
                 enteApiService,
                 environment,
                 applicationZoneId,
-                3_600_000L);
+                3_600_000L,
+                rtSendEnabled);
     }
 
     @Test
@@ -105,7 +110,7 @@ class BatchControllerTest {
     }
 
     @Test
-    @DisplayName("eseguiJobEndpoint avvia anche rtSendJob in modalita' best-effort")
+    @DisplayName("eseguiJobEndpoint avvia anche rtSendJob in modalita' best-effort (flag abilitato)")
     void eseguiJobEndpointAlsoTriggersRtSendJob() throws Exception {
         controller.eseguiJobEndpoint(false);
 
@@ -115,6 +120,19 @@ class BatchControllerTest {
                 .atMost(java.time.Duration.ofSeconds(2))
                 .untilAsserted(() ->
                         verify(jobExecutionHelper).executeIfPossible(rtSendJob, Costanti.RT_SEND_JOB_NAME));
+    }
+
+    @Test
+    @DisplayName("eseguiJobEndpoint NON avvia rtSendJob se govpay.batch.rt-send.enabled=false")
+    void eseguiJobEndpointSkipsRtSendJobWhenDisabled() throws Exception {
+        BatchController disabledController = buildController(false);
+
+        disabledController.eseguiJobEndpoint(false);
+
+        // Diamo tempo a un eventuale runAsync di partire (max ~1s) per essere sicuri che NON parta.
+        Thread.sleep(500);
+        org.mockito.Mockito.verify(jobExecutionHelper, org.mockito.Mockito.never())
+                .executeIfPossible(rtSendJob, Costanti.RT_SEND_JOB_NAME);
     }
 
     @Test


### PR DESCRIPTION
…izione RT.

Quando la proprieta' (default false) e' disabilitata, oltre a non istanziare il runner schedulato (gia' coperto da @ConditionalOnProperty), il BatchController salta anche il lancio best-effort di rtSendJob dall'endpoint /api/batch/run. Quando abilitata, il job parte sia da cron sia da API. Aggiornato il commento in application.properties; test del BatchController parametrizzato sul flag, aggiunto un caso che verifica lo skip a flag spento.