### PR TITLE
Rimossa proprieta' govpay.url, non utilizzata.

### DIFF
--- a/src/main/java/it/govpay/notify/batch/gde/service/GdeService.java
+++ b/src/main/java/it/govpay/notify/batch/gde/service/GdeService.java
@@ -6,7 +6,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
@@ -41,9 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 public class GdeService extends AbstractGdeService {
     private final EventoRtMapper eventoRtMapper;
     private final ConfigurazioneService configurazioneService;
-
-    @Value("${govpay.url}")
-    private String govpayUrl;
 
     public GdeService(ObjectMapper objectMapper,
                       @Qualifier("asyncHttpExecutor") Executor asyncHttpExecutor,


### PR DESCRIPTION
Il campo govpayUrl in GdeService era iniettato via @Value("${govpay.url}") senza default ma non veniva mai letto da nessun metodo. Risultato: dead code che pero' faceva fallire l'avvio dell'applicazione (placeholder non risolvibile) se la proprieta' non era impostata. Rimosso il campo e il relativo import: govpay.url non e' piu' una proprieta' richiesta dall'applicazione.